### PR TITLE
Simplify grant details card spacing

### DIFF
--- a/packages/dapp/src/components/GrantDetails.tsx
+++ b/packages/dapp/src/components/GrantDetails.tsx
@@ -93,27 +93,20 @@ export const GrantDetails: React.FC<Props> = ({
           })}
         </Text>
       </Flex>
-      <SimpleGrid
-        columns={[1, 2, 3]}
-        spacing={8}
-        letterSpacing="0.3px"
-        justifySelf="flex-end"
-        mb={4}
-        p={2}
-      >
-        <Flex direction="column" h="100%" justify="space-between">
+      <SimpleGrid columns={[1, 2, 3]} letterSpacing="0.3px" mb={4} p={2}>
+        <Flex direction="column" mr={16} mb={6}>
           <Text fontFamily="Roboto Mono, monospace" fontSize="2xl" color="dark">
             {`Ξ${formatValue(grant.pledged, 3)}`}
           </Text>
           <Text textTransform="uppercase">Pledged</Text>
         </Flex>
-        <Flex direction="column" h="100%" justify="space-between">
+        <Flex direction="column" mr={16} mb={6}>
           <Text fontFamily="Roboto Mono, monospace" fontSize="2xl" color="dark">
             {`Ξ${formatValue(grant.funded, 3)}`}
           </Text>
           <Text textTransform="uppercase">Paid Out</Text>
         </Flex>
-        <Flex direction="column" h="100%" justify="space-between">
+        <Flex direction="column" mr={16} mb={4}>
           <Text fontFamily="Roboto Mono, monospace" fontSize="2xl" color="dark">
             {`Ξ${formatValue(grant.vested, 3)}`}
           </Text>


### PR DESCRIPTION
Attempt at fixing the spacing weirdness bug on iOS mobile. Maybe we could merge into staging and see if it works?